### PR TITLE
Add option to preset categories

### DIFF
--- a/dfencoder/autoencoder.py
+++ b/dfencoder/autoencoder.py
@@ -996,6 +996,9 @@ class AutoEncoder(torch.nn.Module):
             x = torch.cat(num + bin + embeddings, dim=1)
             x = self.encode(x)
             output_df = self.decode_to_df(x)
+            
+        # set the index of the prediction df to match the input df    
+        output_df.index = df.index
 
         mse, bce, cce = self.get_anomaly_score_losses(df)
         mse_scaled, bce_scaled, cce_scaled = self.scale_losses(mse, bce, cce)

--- a/dfencoder/autoencoder.py
+++ b/dfencoder/autoencoder.py
@@ -165,6 +165,7 @@ class AutoEncoder(torch.nn.Module):
                  progress_bar=True,
                  n_megabatches=1,
                  scaler='standard',
+                 preset_cats=None,
                  *args,
                  **kwargs):
         super(AutoEncoder, self).__init__(*args, **kwargs)
@@ -180,6 +181,7 @@ class AutoEncoder(torch.nn.Module):
         self.encoder_dropout = encoder_dropout
         self.decoder_dropout = decoder_dropout
         self.min_cats = min_cats
+        self.preset_cats = preset_cats
         self.encoder = []
         self.decoder = []
         self.train_mode = self.train
@@ -330,8 +332,11 @@ class AutoEncoder(torch.nn.Module):
         self.bin_names = list(self.binary_fts.keys())
 
     def init_features(self, df):
+        if self.preset_cats is not None:
+            self.categorical_fts = self.preset_cats
+        else:
+            self.init_cats(df)
         self.init_numeric(df)
-        self.init_cats(df)
         self.init_binary(df)
 
     def build_inputs(self):


### PR DESCRIPTION
Add `preset_cats` option to AutoEncoder constructor that allows you to preset categories for all features. If `None` (default) then categories will be determined from input dataframe as before.