### PR TITLE
Prevent result from being an undefined variable

### DIFF
--- a/dfencoder/scalers.py
+++ b/dfencoder/scalers.py
@@ -27,6 +27,8 @@ class StandardScaler(object):
             result = x.to(dtype=torch.float32, copy=True)
         elif (isinstance(x, np.ndarray)):
             result = x.astype(float)
+        else:
+            raise ValueError(f"Unsupported type: {type(x)}")
 
         result -= self.mean
         result /= self.std


### PR DESCRIPTION
Raises a `ValueError` when `x` isn't one of the unexpected types.

Avoids an `UnboundLocalError: local variable 'result' referenced before assignment` error

Not sure if this is specific to our fork or if it should be contributed upstream.